### PR TITLE
fix: correct secret paths and env variable names

### DIFF
--- a/ansible/host_vars/gate-bracha.xvx.cz
+++ b/ansible/host_vars/gate-bracha.xvx.cz
@@ -67,7 +67,7 @@ openwrt_packages:
   - rsync
   # keep-sorted end
 
-root_password: "{{ lookup('env', 'GATE_XVX_CZ_ROOT_PASSWORD') }}"
+root_password: "{{ lookup('env', 'GATE_BRACHA_XVX_CZ_ROOT_PASSWORD') }}"
 
 usb_disk_device: sda
 
@@ -75,7 +75,7 @@ usb_disk_fs_type: btrfs
 
 usb_disk_mount_path: /mnt
 
-wifi_password: "{{ lookup('env', 'GATE_XVX_CZ_WIFI_PASSWORD') }}"
+wifi_password: "{{ lookup('env', 'GATE_BRACHA_XVX_CZ_WIFI_PASSWORD') }}"
 
 wifi_ssid: kerova11
 

--- a/fnox.toml
+++ b/fnox.toml
@@ -2,15 +2,15 @@
 ps = { type = "aws-ps", profile = "my-aws", region = "eu-central-1" }
 
 [secrets]
-GATE_BRACHA_XVX_CZ_DROPBEAR_ED25519_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate-bracha.xvx.cz/dropbear_ed25519_host_key", if_missing = "error" }
-GATE_BRACHA_XVX_CZ_DROPBEAR_RSA_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate-bracha.xvx.cz/dropbear_rsa_host_key", if_missing = "error" }
-GATE_BRACHA_XVX_CZ_MSMP_AUTH_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate-bracha.xvx.cz/msmtp_auth_password", if_missing = "error" }
-GATE_BRACHA_XVX_CZ_ROOT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate-bracha.xvx.cz/root_password", if_missing = "error" }
-GATE_BRACHA_XVX_CZ_WIFI_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate-bracha.xvx.cz/wifi_password", if_missing = "error" }
-GATE_XVX_CZ_CLOUDFLARE_API_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate.xvx.cz/cloudflare_api_key", if_missing = "error" }
-GATE_XVX_CZ_DROPBEAR_ED25519_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate.xvx.cz/dropbear_ed25519_host_key", if_missing = "error" }
-GATE_XVX_CZ_DROPBEAR_RSA_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate.xvx.cz/dropbear_rsa_host_key", if_missing = "error" }
-GATE_XVX_CZ_LUCI_HOMEPAGE_OPENWRT_WIDGET_PASSWORD_HASH = { provider = "ps", value = "/github/shared/gate.xvx.cz/luci_homepage_openwrt_widget_password_hash", if_missing = "error" }
-GATE_XVX_CZ_MSMP_AUTH_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate.xvx.cz/msmtp_auth_password", if_missing = "error" }
-GATE_XVX_CZ_ROOT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/ansible/gate.xvx.cz/root_password", if_missing = "error" }
+GATE_BRACHA_XVX_CZ_DROPBEAR_ED25519_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/DROPBEAR_ED25519_HOST_KEY", if_missing = "error" }
+GATE_BRACHA_XVX_CZ_DROPBEAR_RSA_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/DROPBEAR_RSA_HOST_KEY", if_missing = "error" }
+GATE_BRACHA_XVX_CZ_MSMP_AUTH_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/MSMTP_AUTH_PASSWORD", if_missing = "error" }
+GATE_BRACHA_XVX_CZ_ROOT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/ROOT_PASSWORD", if_missing = "error" }
+GATE_BRACHA_XVX_CZ_WIFI_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/WIFI_PASSWORD", if_missing = "error" }
+GATE_XVX_CZ_CLOUDFLARE_API_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/CLOUDFLARE_API_KEY", if_missing = "error" }
+GATE_XVX_CZ_DROPBEAR_ED25519_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/DROPBEAR_ED25519_HOST_KEY", if_missing = "error" }
+GATE_XVX_CZ_DROPBEAR_RSA_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/DROPBEAR_RSA_HOST_KEY", if_missing = "error" }
+GATE_XVX_CZ_LUCI_HOMEPAGE_OPENWRT_WIDGET_PASSWORD_HASH = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/LUCI_HOMEPAGE_OPENWRT_WIDGET_PASSWORD_HASH", if_missing = "error" }
+GATE_XVX_CZ_MSMP_AUTH_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/MSMTP_AUTH_PASSWORD", if_missing = "error" }
+GATE_XVX_CZ_ROOT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/ROOT_PASSWORD", if_missing = "error" }
 GATE_XVX_CZ_WIFI_PASSWORD = { provider = "ps", value = "/github/shared/actions-secrets/WIFI_PASSWORD", if_missing = "error" }


### PR DESCRIPTION
## Summary

- Fix `gate-bracha.xvx.cz` host vars to use correct `GATE_BRACHA_XVX_CZ_` prefix for root password and wifi password env variables
- Reorganize AWS Parameter Store paths in `fnox.toml`: remove `ansible/` prefix and uppercase secret names for consistency