### PR TITLE
feat: remove dropbear RSA host key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ansible playbooks configuring OpenWrt devices (Wi-Fi routers)
 > 💡 Always [build](https://firmware-selector.openwrt.org/) your own OpenWrt
 > Firmware with installed packages (it will save disk space)
 
-## [ASUS RT-AX53U](https://openwrt.org/toh/asus/rt-ax53u)
+## [ASUS RT-AX53U](https://openwrt.org/toh/asus/rt-ax53u) - gate.xvx.cz
 
 * [Firmware](https://firmware-selector.openwrt.org/?version=24.10.0&target=ramips%2Fmt7621&id=asus_rt-ax53u)
 
@@ -18,12 +18,7 @@ echo "Latest stable: ${LATEST_STABLE}"
 
 BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \
   -H "Content-Type: application/json" \
-  -d "$(jq -n \
-    --arg target "ramips/mt7621" \
-    --arg profile "asus_rt-ax53u" \
-    --arg version "${LATEST_STABLE}" \
-    --argjson packages "${PACKAGES_JSON}" \
-    '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false}')")
+  -d "$(jq -n --arg target "ramips/mt7621" --arg profile "asus_rt-ax53u" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false}')")
 
 REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
 echo "Request hash: ${REQUEST_HASH}"
@@ -55,29 +50,29 @@ echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
 ### Flash router and allow SSH access to the router form the WAN
 
 ```bash
-# Flash OpenWrt firmware
-sysupgrade -p -n -v https://sysupgrade.openwrt.org/store/834d5261fadfab7d4f781ca4aefc8c9d8a9492bfd832365b4f1bcb0bea0de956/openwrt-24.10.0-0a8242515cd3-ipq40xx-generic-zyxel_nbg6617-squashfs-sysupgrade.bin
-
 # Set root password
 passwd
 
 # Enable SSH access from the WAN
 wget https://github.com/ruzickap.keys -O /etc/dropbear/authorized_keys
 
-uci add firewall rule
-uci set firewall.@rule[-1].name=Allow-SSH
-uci set firewall.@rule[-1].src=wan
-uci set firewall.@rule[-1].target=ACCEPT
-uci set firewall.@rule[-1].proto=tcp
-uci set firewall.@rule[-1].dest_port=22
+cat >> /etc/config/firewall << 'EOF'
 
-uci add firewall redirect
-uci set firewall.@redirect[-1].name=Allow-SSH-22222
-uci set firewall.@redirect[-1].src=wan
-uci set firewall.@redirect[-1].proto=tcp
-uci set firewall.@redirect[-1].src_dport=22222
-uci set firewall.@redirect[-1].dest=lan
-uci set firewall.@redirect[-1].dest_port=22
-uci commit
+config rule
+	option name 'Allow-SSH'
+	option src 'wan'
+	option target 'ACCEPT'
+	option proto 'tcp'
+	option dest_port '22'
+
+config redirect
+	option name 'Allow-SSH-22222'
+	option src 'wan'
+	option proto 'tcp'
+	option src_dport '22222'
+	option dest 'lan'
+	option dest_port '22'
+EOF
+
 /etc/init.d/firewall restart
 ```

--- a/ansible/host_vars/gate-bracha.xvx.cz
+++ b/ansible/host_vars/gate-bracha.xvx.cz
@@ -6,8 +6,6 @@ dhcp_hosts:
 
 dropbear_ed25519_host_key: "{{ lookup('env', 'GATE_BRACHA_XVX_CZ_DROPBEAR_ED25519_HOST_KEY') }}"
 
-dropbear_rsa_host_key: "{{ lookup('env', 'GATE_BRACHA_XVX_CZ_DROPBEAR_RSA_HOST_KEY') }}"
-
 enable_boot_services:
   - banip
   - collectd

--- a/ansible/host_vars/gate.xvx.cz
+++ b/ansible/host_vars/gate.xvx.cz
@@ -17,8 +17,6 @@ dhcp_hosts:
 
 dropbear_ed25519_host_key: "{{ lookup('env', 'GATE_XVX_CZ_DROPBEAR_ED25519_HOST_KEY') }}"
 
-dropbear_rsa_host_key: "{{ lookup('env', 'GATE_XVX_CZ_DROPBEAR_RSA_HOST_KEY') }}"
-
 guest_network_ip_subnet: 172.16.254.1/24
 
 interfaces:

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -4,20 +4,20 @@
     src: files/{{ inventory_hostname }}/etc/config/system.j2
     mode: u=rw,g=,o=
 
-- name: Create dropbear_*_host_key for dropbear
+- name: Create dropbear_ed25519_host_key for dropbear
   shell: |
     python3 - <<'PY'
     import base64, pathlib
-    data = base64.b64decode("{{ item.content }}")
-    pathlib.Path("{{ item.file }}").write_bytes(data)
+    data = base64.b64decode("{{ dropbear_ed25519_host_key }}")
+    pathlib.Path("/etc/dropbear/dropbear_ed25519_host_key").write_bytes(data)
     PY
-  loop:
-    - file: /etc/dropbear/dropbear_ed25519_host_key
-      content: "{{ dropbear_ed25519_host_key }}"
-    - file: /etc/dropbear/dropbear_rsa_host_key
-      content: "{{ dropbear_rsa_host_key }}"
   changed_when: false
   no_log: true
+
+- name: Remove dropbear RSA host key
+  ansible.builtin.file:
+    path: /etc/dropbear/dropbear_rsa_host_key
+    state: absent
 
 - name: Create authorized_keys for dropbear (/etc/dropbear/authorized_keys)
   ansible.builtin.template:

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -14,11 +14,6 @@
   changed_when: false
   no_log: true
 
-- name: Remove dropbear RSA host key
-  ansible.builtin.file:
-    path: /etc/dropbear/dropbear_rsa_host_key
-    state: absent
-
 - name: Create authorized_keys for dropbear (/etc/dropbear/authorized_keys)
   ansible.builtin.template:
     dest: /etc/dropbear/authorized_keys

--- a/fnox.toml
+++ b/fnox.toml
@@ -3,13 +3,11 @@ ps = { type = "aws-ps", profile = "my-aws", region = "eu-central-1" }
 
 [secrets]
 GATE_BRACHA_XVX_CZ_DROPBEAR_ED25519_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/DROPBEAR_ED25519_HOST_KEY", if_missing = "error" }
-GATE_BRACHA_XVX_CZ_DROPBEAR_RSA_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/DROPBEAR_RSA_HOST_KEY", if_missing = "error" }
 GATE_BRACHA_XVX_CZ_MSMP_AUTH_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/MSMTP_AUTH_PASSWORD", if_missing = "error" }
 GATE_BRACHA_XVX_CZ_ROOT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/ROOT_PASSWORD", if_missing = "error" }
 GATE_BRACHA_XVX_CZ_WIFI_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate-bracha.xvx.cz/WIFI_PASSWORD", if_missing = "error" }
 GATE_XVX_CZ_CLOUDFLARE_API_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/CLOUDFLARE_API_KEY", if_missing = "error" }
 GATE_XVX_CZ_DROPBEAR_ED25519_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/DROPBEAR_ED25519_HOST_KEY", if_missing = "error" }
-GATE_XVX_CZ_DROPBEAR_RSA_HOST_KEY = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/DROPBEAR_RSA_HOST_KEY", if_missing = "error" }
 GATE_XVX_CZ_LUCI_HOMEPAGE_OPENWRT_WIDGET_PASSWORD_HASH = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/LUCI_HOMEPAGE_OPENWRT_WIDGET_PASSWORD_HASH", if_missing = "error" }
 GATE_XVX_CZ_MSMP_AUTH_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/MSMTP_AUTH_PASSWORD", if_missing = "error" }
 GATE_XVX_CZ_ROOT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/ROOT_PASSWORD", if_missing = "error" }


### PR DESCRIPTION
## Summary

- Remove dropbear RSA host key variables, secrets, and provisioning
  from both hosts, keeping only Ed25519
- Simplify the dropbear key creation task (no longer uses a loop)
- Add explicit task to remove the RSA host key file from devices
- Clean up related entries from `fnox.toml` secrets config

RSA keys are deprecated in modern OpenSSH/dropbear; Ed25519 is
sufficient and more secure.