### PR TITLE
feat: add build-firmware mise task and pin tool versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,7 @@ Ansible playbooks configuring OpenWrt devices (Wi-Fi routers)
 Build custom firmware using the OpenWrt Sysupgrade API:
 
 ```bash
-PACKAGES_JSON=$(yq -o=json '.openwrt_packages' ansible/host_vars/gate.xvx.cz)
-LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' | sort -V | tail -n 1)
-echo "Latest stable: ${LATEST_STABLE}"
-
-BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \
-  -H "Content-Type: application/json" \
-  -d "$(jq -n --arg target "ramips/mt7621" --arg profile "asus_rt-ax53u" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false}')")
-
-REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
-echo "Request hash: ${REQUEST_HASH}"
-
-while true; do
-  HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
-  echo "Build status: ${HTTP_CODE}"
-  if [[ "${HTTP_CODE}" == "200" ]]; then
-    break
-  fi
-  sleep 10
-done
-
-BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
-IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
-IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
-echo "🔍 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
-echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
+mise run build-firmware
 ```
 
 ## [ZyXEL NBG6617](https://openwrt.org/toh/zyxel/nbg6617)

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
 ansible = "13.6.0"
 fnox = "1.23.0"
-"github:harehare/mq" = "0.5.29"
 pipx = "1.12.0"
 
 [plugins]
@@ -15,7 +14,31 @@ description = "Build custom OpenWrt firmware for ASUS RT-AX53U (gate.xvx.cz) usi
 shell = "bash -c"
 run = """
 set -euxo pipefail
-eval "$(mq -F json '.code' README.md | jq -r '.[0].value')"
+PACKAGES_JSON=$(yq -o=json '.openwrt_packages' ansible/host_vars/gate.xvx.cz)
+LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))' | sort -V | tail -n 1)
+echo "Latest stable: ${LATEST_STABLE}"
+
+BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \\
+  -H "Content-Type: application/json" \\
+  -d "$(jq -n --arg target "ramips/mt7621" --arg profile "asus_rt-ax53u" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false}')")
+
+REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
+echo "Request hash: ${REQUEST_HASH}"
+
+while true; do
+  HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
+  echo "Build status: ${HTTP_CODE}"
+  if [[ "${HTTP_CODE}" == "200" ]]; then
+    break
+  fi
+  sleep 10
+done
+
+BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
+IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
+IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
+echo "🔍 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
+echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
 """
 
 [tasks.run]

--- a/mise.toml
+++ b/mise.toml
@@ -1,12 +1,22 @@
 [tools]
-# ansible = "latest"
+ansible = "13.6.0"
 fnox = "1.23.0"
+"github:harehare/mq" = "0.5.29"
+pipx = "1.12.0"
 
 [plugins]
 fnox-env = "https://github.com/jdx/mise-env-fnox"
 
 [env]
 _.fnox-env = { tools = true }
+
+[tasks.build-firmware]
+description = "Build custom OpenWrt firmware for ASUS RT-AX53U (gate.xvx.cz) using the Sysupgrade API"
+shell = "bash -c"
+run = """
+set -euxo pipefail
+eval "$(mq -F json '.code' README.md | jq -r '.[0].value')"
+"""
 
 [tasks.run]
 description = "Run Ansible playbook"


### PR DESCRIPTION
## Summary

- Add `build-firmware` mise task that extracts and runs the firmware build script from `README.md` using `mq`
- Add `ansible`, `mq` (via github backend), and `pipx` to mise tools with pinned versions
- Enable ansible installation via the pipx backend