### PR TITLE
feat: add firmware build improvements and ansible enhancements

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -21,6 +21,10 @@
     - name: Include specific tasks
       ansible.builtin.include_tasks: tasks/tasks_{{ inventory_hostname }}.yml
 
+    - name: Reboot the router
+      ansible.builtin.command: reboot
+      changed_when: true
+
   handlers:
     - name: Import handlers
       ansible.builtin.import_tasks: handlers/main.yml

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -3,6 +3,7 @@
     dest: /etc/config/system
     src: files/{{ inventory_hostname }}/etc/config/system.j2
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Create dropbear_ed25519_host_key for dropbear
   shell: |
@@ -19,24 +20,28 @@
     dest: /etc/dropbear/authorized_keys
     src: files/etc/dropbear/authorized_keys.j2
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Configure networks
   ansible.builtin.template:
     dest: /etc/config/network
     src: files/{{ inventory_hostname }}/etc/config/network.j2
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Configure Firewall
   ansible.builtin.copy:
     dest: /etc/config/firewall
     src: files/{{ inventory_hostname }}/etc/config/firewall
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Configure WiFi
   ansible.builtin.template:
     dest: /etc/config/wireless
     src: files/{{ inventory_hostname }}/etc/config/wireless.j2
     mode: u=rw,g=r,o=r
+    backup: true
   no_log: true
 
 - name: Set root password
@@ -44,6 +49,7 @@
     path: /etc/shadow
     regexp: "^root:([^:]*):"
     replace: "root:{{ root_password | string | password_hash('sha256') }}:"
+    backup: true
   changed_when: false
 
 - name: Install packages
@@ -55,16 +61,19 @@
     dest: /etc/config/dhcp
     src: files/{{ inventory_hostname }}/etc/config/dhcp.j2
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Change root shell to /bin/bash
   ansible.builtin.replace:
     path: /etc/passwd
     regexp: "^root:(.*):/bin/ash"
     replace: "root:\\1:/bin/bash"
+    backup: true
 
 - name: Add nice prompt for root user
   ansible.builtin.blockinfile:
     dest: /etc/profile
+    backup: true
     block: |
       ps1_prompt() {
           local ps1_exit=$?
@@ -90,6 +99,7 @@
   ansible.builtin.copy:
     dest: /etc/profile.d/history_format.sh
     mode: u=rw,g=r,o=r
+    backup: true
     content: |
       HISTTIMEFORMAT="|%F %R| "
 
@@ -98,18 +108,21 @@
     dest: /etc/config/vnstat
     src: files/{{ inventory_hostname }}/etc/config/vnstat.j2
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Luci statistics (/etc/config/luci_statistics)
   ansible.builtin.template:
     dest: /etc/config/luci_statistics
     src: files/{{ inventory_hostname }}/etc/config/luci_statistics.j2
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Configure uhttpd (Use HTTPS for LuCI)
   ansible.builtin.copy:
     dest: /etc/config/uhttpd
     src: files/{{ inventory_hostname }}/etc/config/uhttpd
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Create directory for mc inside ~/.config
   ansible.builtin.file:
@@ -121,6 +134,7 @@
   ansible.builtin.copy:
     dest: ~/.config/mc/ini
     mode: u=rw,g=r,o=r
+    backup: true
     content: |
       [Midnight-Commander]
       auto_save_setup=0
@@ -141,6 +155,7 @@
   ansible.builtin.copy:
     dest: /etc/profile.d/my-mc.sh
     mode: u=rwx,g=rx,o=rx
+    backup: true
     content: |
       #!/usr/bin/env sh
 
@@ -153,6 +168,7 @@
     dest: /etc/config/banip
     src: files/{{ inventory_hostname }}/etc/config/banip
     mode: u=rw,g=,o=
+    backup: true
 
 ############################################
 # Configure msmtp + email notifications
@@ -163,6 +179,7 @@
     dest: /etc/msmtprc
     src: files/etc/msmtprc.j2
     mode: u=rw,g=,o=
+    backup: true
   no_log: true
 
 - name: Reboot notification
@@ -170,3 +187,4 @@
     dest: /etc/rc.local
     src: files/etc/rc.local.j2
     mode: u=rwx,g=rx,o=rx
+    backup: true

--- a/ansible/tasks/tasks_gate.xvx.cz.yml
+++ b/ansible/tasks/tasks_gate.xvx.cz.yml
@@ -9,6 +9,7 @@
         dest: /etc/config/fstab
         src: files/{{ inventory_hostname }}/etc/config/fstab.j2
         mode: u=rw,g=r,o=r
+        backup: true
 
     - name: Create directory {{ usb_disk_mount_path }}
       ansible.builtin.file:
@@ -54,6 +55,7 @@
         dest: /etc/config/hd-idle
         src: files/{{ inventory_hostname }}/etc/config/hd-idle
         mode: u=rw,g=,o=
+        backup: true
   rescue:
     - name: Print when errors
       ansible.builtin.fail:
@@ -73,6 +75,7 @@
     dest: /etc/init.d/collectd_nlbwmon_vnstat-backup
     src: files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
     mode: u=rwx,g=rx,o=rx
+    backup: true
   notify: Enable collectd_nlbwmon_vnstat-backup on boot + restore data from backup
 
 - name: Configure to run collectd_nlbwmon_vnstat-backup daily
@@ -92,12 +95,14 @@
     dest: /etc/config/prometheus-node-exporter-ucode
     src: files/{{ inventory_hostname }}/etc/config/prometheus-node-exporter-ucode
     mode: u=rw,g=,o=
+    backup: true
 
 - name: Configure cloudflared
   ansible.builtin.template:
     dest: /etc/config/cloudflared
     src: files/{{ inventory_hostname }}/etc/config/cloudflared.j2
     mode: u=rw,g=,o=
+    backup: true
 
 ############################################
 # Transmission
@@ -108,6 +113,7 @@
     dest: /etc/config/transmission
     src: files/{{ inventory_hostname }}/etc/config/transmission.j2
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Start transmission
   community.general.openwrt_init:
@@ -134,12 +140,14 @@
     dest: /usr/share/rpcd/acl.d/homepage.json
     src: files/{{ inventory_hostname }}/usr/share/rpcd/acl.d/homepage.json
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Allow Homepage OpenWRT widget to access Luci via RPC
   ansible.builtin.template:
     dest: /etc/config/rpcd
     src: files/{{ inventory_hostname }}/etc/config/rpcd.j2
     mode: u=rw,g=r,o=r
+    backup: true
   no_log: true
 
 - name: Configure samba4
@@ -147,3 +155,4 @@
     dest: /etc/config/samba4
     src: files/{{ inventory_hostname }}/etc/config/samba4.j2
     mode: u=rw,g=,o=
+    backup: true

--- a/mise.toml
+++ b/mise.toml
@@ -31,16 +31,7 @@ WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate-bracha.xvx.cz)
 DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${GATE_BRACHA_XVX_CZ_WIFI_PASSWORD}'
-uci commit wireless
-uci set firewall.allow_wan_ssh=rule
-uci set firewall.allow_wan_ssh.name='Allow-WAN-SSH'
-uci set firewall.allow_wan_ssh.src='wan'
-uci set firewall.allow_wan_ssh.dest_port='22'
-uci set firewall.allow_wan_ssh.proto='tcp'
-uci set firewall.allow_wan_ssh.target='ACCEPT'
-uci commit firewall
-mkdir -p /etc/dropbear
-wget -qO /etc/dropbear/authorized_keys https://github.com/ruzickap.keys"
+uci commit wireless"
 scripts/build-firmware.sh "ipq40xx/generic" "zyxel_nbg6617" "ansible/host_vars/gate-bracha.xvx.cz" "${DEFAULTS}"
 """
 

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@ fnox-env = "https://github.com/jdx/mise-env-fnox"
 [env]
 _.fnox-env = { tools = true }
 
-[tasks.build-firmware]
+[tasks."build-firmware:gate-xvx-cz"]
 description = "Build custom OpenWrt firmware for ASUS RT-AX53U (gate.xvx.cz) using the Sysupgrade API"
 shell = "bash -c"
 run = """
@@ -18,11 +18,22 @@ PACKAGES_JSON=$(yq -o=json '.openwrt_packages' ansible/host_vars/gate.xvx.cz)
 LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))' | sort -V | tail -n 1)
 echo "Latest stable: ${LATEST_STABLE}"
 
+WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate.xvx.cz)
+WIFI_DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+uci set wireless.default_radio1.encryption='sae-mixed'
+uci set wireless.default_radio1.key='${GATE_XVX_CZ_WIFI_PASSWORD}'
+uci commit wireless"
+
 BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \\
   -H "Content-Type: application/json" \\
-  -d "$(jq -n --arg target "ramips/mt7621" --arg profile "asus_rt-ax53u" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false}')")
+  -d "$(jq -n --arg target "ramips/mt7621" --arg profile "asus_rt-ax53u" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" --arg defaults "${WIFI_DEFAULTS}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false, defaults: $defaults}')")
 
 REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
+if [[ "${REQUEST_HASH}" == "null" ]]; then
+  echo "Build request failed:"
+  jq . <<< "${BUILD_RESPONSE}"
+  exit 1
+fi
 echo "Request hash: ${REQUEST_HASH}"
 
 while true; do
@@ -30,8 +41,13 @@ while true; do
   echo "Build status: ${HTTP_CODE}"
   if [[ "${HTTP_CODE}" == "200" ]]; then
     break
+  elif [[ "${HTTP_CODE}" == "202" ]]; then
+    sleep 10
+  else
+    echo "Build failed (HTTP ${HTTP_CODE}):"
+    jq . /tmp/build_status.json
+    exit 1
   fi
-  sleep 10
 done
 
 BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
@@ -41,15 +57,85 @@ echo "🔍 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQU
 echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
 """
 
-[tasks.run]
-description = "Run Ansible playbook"
+[tasks."build-firmware:gate-bracha-xvx-cz"]
+description = "Build custom OpenWrt firmware for ZyXEL NBG6617 (gate-bracha.xvx.cz) using the Sysupgrade API"
+shell = "bash -c"
+run = """
+set -euxo pipefail
+PACKAGES_JSON=$(yq -o=json '.openwrt_packages' ansible/host_vars/gate-bracha.xvx.cz)
+LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))' | sort -V | tail -n 1)
+echo "Latest stable: ${LATEST_STABLE}"
+
+WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate-bracha.xvx.cz)
+WIFI_DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+uci set wireless.default_radio1.encryption='sae-mixed'
+uci set wireless.default_radio1.key='${GATE_BRACHA_XVX_CZ_WIFI_PASSWORD}'
+uci commit wireless
+uci set firewall.allow_wan_ssh=rule
+uci set firewall.allow_wan_ssh.name='Allow-WAN-SSH'
+uci set firewall.allow_wan_ssh.src='wan'
+uci set firewall.allow_wan_ssh.dest_port='22'
+uci set firewall.allow_wan_ssh.proto='tcp'
+uci set firewall.allow_wan_ssh.target='ACCEPT'
+uci commit firewall
+mkdir -p /etc/dropbear
+wget -qO /etc/dropbear/authorized_keys https://github.com/ruzickap.keys"
+
+BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \\
+  -H "Content-Type: application/json" \\
+  -d "$(jq -n --arg target "ipq40xx/generic" --arg profile "zyxel_nbg6617" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" --arg defaults "${WIFI_DEFAULTS}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false, defaults: $defaults}')")
+
+REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
+if [[ "${REQUEST_HASH}" == "null" ]]; then
+  echo "Build request failed:"
+  jq . <<< "${BUILD_RESPONSE}"
+  exit 1
+fi
+echo "Request hash: ${REQUEST_HASH}"
+
+while true; do
+  HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
+  echo "Build status: ${HTTP_CODE}"
+  if [[ "${HTTP_CODE}" == "200" ]]; then
+    break
+  elif [[ "${HTTP_CODE}" == "202" ]]; then
+    sleep 10
+  else
+    echo "Build failed (HTTP ${HTTP_CODE}):"
+    jq . /tmp/build_status.json
+    exit 1
+  fi
+done
+
+BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
+IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
+IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
+echo "🔍 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
+echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
+"""
+
+[tasks."run-ansible:gate-xvx-cz"]
+description = "Run Ansible playbook for gate.xvx.cz"
 dir = "ansible"
 shell = "bash -c"
 run = """
 set -euxo pipefail
 if [ ! -f /tmp/ansible-openwrt.log ]; then
-  ansible-playbook --diff main.yml -i inventory/hosts 2>&1 | tee /tmp/ansible-openwrt.log
+  ansible-playbook --diff main.yml -i inventory/hosts --limit gate.xvx.cz 2>&1 | tee /tmp/ansible-openwrt.log
 else
-  ansible-playbook --diff main.yml -i inventory/hosts
+  ansible-playbook --diff main.yml -i inventory/hosts --limit gate.xvx.cz
+fi
+"""
+
+[tasks."run-ansible:gate-bracha-xvx-cz"]
+description = "Run Ansible playbook for gate-bracha.xvx.cz"
+dir = "ansible"
+shell = "bash -c"
+run = """
+set -euxo pipefail
+if [ ! -f /tmp/ansible-openwrt-bracha.log ]; then
+  ansible-playbook --diff main.yml -i inventory/hosts --limit gate-bracha.xvx.cz 2>&1 | tee /tmp/ansible-openwrt-bracha.log
+else
+  ansible-playbook --diff main.yml -i inventory/hosts --limit gate-bracha.xvx.cz
 fi
 """

--- a/mise.toml
+++ b/mise.toml
@@ -10,30 +10,12 @@ fnox-env = "https://github.com/jdx/mise-env-fnox"
 _.fnox-env = { tools = true }
 
 [tasks."build-firmware:gate-xvx-cz"]
-description = "Build custom OpenWrt firmware for ASUS RT-AX53U (gate.xvx.cz) using the Sysupgrade API"
-shell = "bash -c"
-run = """
-set -euxo pipefail
-WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate.xvx.cz)
-DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
-uci set wireless.default_radio1.encryption='sae-mixed'
-uci set wireless.default_radio1.key='${GATE_XVX_CZ_WIFI_PASSWORD}'
-uci commit wireless"
-scripts/build-firmware.sh "ramips/mt7621" "asus_rt-ax53u" "ansible/host_vars/gate.xvx.cz" "${DEFAULTS}"
-"""
+description = "Build custom OpenWrt firmware for ASUS RT-AX53U (gate.xvx.cz)"
+run = 'scripts/build-firmware.sh "ramips/mt7621" "asus_rt-ax53u" "gate.xvx.cz"'
 
 [tasks."build-firmware:gate-bracha-xvx-cz"]
-description = "Build custom OpenWrt firmware for ZyXEL NBG6617 (gate-bracha.xvx.cz) using the Sysupgrade API"
-shell = "bash -c"
-run = """
-set -euxo pipefail
-WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate-bracha.xvx.cz)
-DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
-uci set wireless.default_radio1.encryption='sae-mixed'
-uci set wireless.default_radio1.key='${GATE_BRACHA_XVX_CZ_WIFI_PASSWORD}'
-uci commit wireless"
-scripts/build-firmware.sh "ipq40xx/generic" "zyxel_nbg6617" "ansible/host_vars/gate-bracha.xvx.cz" "${DEFAULTS}"
-"""
+description = "Build custom OpenWrt firmware for ZyXEL NBG6617 (gate-bracha.xvx.cz)"
+run = 'scripts/build-firmware.sh "ipq40xx/generic" "zyxel_nbg6617" "gate-bracha.xvx.cz"'
 
 [tasks."run-ansible:gate-xvx-cz"]
 description = "Run Ansible playbook for gate.xvx.cz"

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,8 @@ LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/late
 echo "Latest stable: ${LATEST_STABLE}"
 
 WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate.xvx.cz)
-WIFI_DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+WIFI_DEFAULTS="# $(date -u +%Y%m%d%H%M%S)
+uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${GATE_XVX_CZ_WIFI_PASSWORD}'
 uci commit wireless"
@@ -67,7 +68,8 @@ LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/late
 echo "Latest stable: ${LATEST_STABLE}"
 
 WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate-bracha.xvx.cz)
-WIFI_DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+WIFI_DEFAULTS="# $(date -u +%Y%m%d%H%M%S)
+uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${GATE_BRACHA_XVX_CZ_WIFI_PASSWORD}'
 uci commit wireless

--- a/mise.toml
+++ b/mise.toml
@@ -14,48 +14,12 @@ description = "Build custom OpenWrt firmware for ASUS RT-AX53U (gate.xvx.cz) usi
 shell = "bash -c"
 run = """
 set -euxo pipefail
-PACKAGES_JSON=$(yq -o=json '.openwrt_packages' ansible/host_vars/gate.xvx.cz)
-LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))' | sort -V | tail -n 1)
-echo "Latest stable: ${LATEST_STABLE}"
-
 WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate.xvx.cz)
-WIFI_DEFAULTS="# $(date -u +%Y%m%d%H%M%S)
-uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${GATE_XVX_CZ_WIFI_PASSWORD}'
 uci commit wireless"
-
-BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \\
-  -H "Content-Type: application/json" \\
-  -d "$(jq -n --arg target "ramips/mt7621" --arg profile "asus_rt-ax53u" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" --arg defaults "${WIFI_DEFAULTS}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false, defaults: $defaults}')")
-
-REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
-if [[ "${REQUEST_HASH}" == "null" ]]; then
-  echo "Build request failed:"
-  jq . <<< "${BUILD_RESPONSE}"
-  exit 1
-fi
-echo "Request hash: ${REQUEST_HASH}"
-
-while true; do
-  HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
-  echo "Build status: ${HTTP_CODE}"
-  if [[ "${HTTP_CODE}" == "200" ]]; then
-    break
-  elif [[ "${HTTP_CODE}" == "202" ]]; then
-    sleep 10
-  else
-    echo "Build failed (HTTP ${HTTP_CODE}):"
-    jq . /tmp/build_status.json
-    exit 1
-  fi
-done
-
-BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
-IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
-IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
-echo "🔍 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
-echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
+scripts/build-firmware.sh "ramips/mt7621" "asus_rt-ax53u" "ansible/host_vars/gate.xvx.cz" "${DEFAULTS}"
 """
 
 [tasks."build-firmware:gate-bracha-xvx-cz"]
@@ -63,13 +27,8 @@ description = "Build custom OpenWrt firmware for ZyXEL NBG6617 (gate-bracha.xvx.
 shell = "bash -c"
 run = """
 set -euxo pipefail
-PACKAGES_JSON=$(yq -o=json '.openwrt_packages' ansible/host_vars/gate-bracha.xvx.cz)
-LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$"))' | sort -V | tail -n 1)
-echo "Latest stable: ${LATEST_STABLE}"
-
 WIFI_SSID=$(yq '.wifi_ssid' ansible/host_vars/gate-bracha.xvx.cz)
-WIFI_DEFAULTS="# $(date -u +%Y%m%d%H%M%S)
-uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${GATE_BRACHA_XVX_CZ_WIFI_PASSWORD}'
 uci commit wireless
@@ -82,38 +41,7 @@ uci set firewall.allow_wan_ssh.target='ACCEPT'
 uci commit firewall
 mkdir -p /etc/dropbear
 wget -qO /etc/dropbear/authorized_keys https://github.com/ruzickap.keys"
-
-BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \\
-  -H "Content-Type: application/json" \\
-  -d "$(jq -n --arg target "ipq40xx/generic" --arg profile "zyxel_nbg6617" --arg version "${LATEST_STABLE}" --argjson packages "${PACKAGES_JSON}" --arg defaults "${WIFI_DEFAULTS}" '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false, defaults: $defaults}')")
-
-REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
-if [[ "${REQUEST_HASH}" == "null" ]]; then
-  echo "Build request failed:"
-  jq . <<< "${BUILD_RESPONSE}"
-  exit 1
-fi
-echo "Request hash: ${REQUEST_HASH}"
-
-while true; do
-  HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
-  echo "Build status: ${HTTP_CODE}"
-  if [[ "${HTTP_CODE}" == "200" ]]; then
-    break
-  elif [[ "${HTTP_CODE}" == "202" ]]; then
-    sleep 10
-  else
-    echo "Build failed (HTTP ${HTTP_CODE}):"
-    jq . /tmp/build_status.json
-    exit 1
-  fi
-done
-
-BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
-IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
-IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
-echo "🔍 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
-echo "👉 sysupgrade -v -n -p ${IMAGE_URL}"
+scripts/build-firmware.sh "ipq40xx/generic" "zyxel_nbg6617" "ansible/host_vars/gate-bracha.xvx.cz" "${DEFAULTS}"
 """
 
 [tasks."run-ansible:gate-xvx-cz"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-ansible = "13.6.0"
+ansible = { version = "13.6.0", pipx_args = "--preinstall passlib" }
 fnox = "1.23.0"
 pipx = "1.12.0"
 

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -13,7 +13,9 @@ WIFI_SSID=$(yq '.wifi_ssid' "${HOST_VARS}")
 WIFI_PASSWORD_VAR=$(echo "${HOSTNAME}" | tr '[:lower:].-' '[:upper:]__')_WIFI_PASSWORD
 WIFI_PASSWORD="${!WIFI_PASSWORD_VAR:?Environment variable ${WIFI_PASSWORD_VAR} is not set}"
 
-DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+DEFAULTS="uci delete wireless.radio0.disabled
+uci delete wireless.radio1.disabled
+uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${WIFI_PASSWORD}'
 uci commit wireless"
@@ -22,7 +24,7 @@ PACKAGES_JSON=$(yq -o=json '.openwrt_packages' "${HOST_VARS}")
 LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest |
   jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' |
   sort -V | tail -n 1)
-echo "Latest stable: ${LATEST_STABLE}"
+echo "✅ Latest stable: ${LATEST_STABLE}"
 
 BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \
   -H "Content-Type: application/json" \
@@ -36,22 +38,22 @@ BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api
 
 REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
 if [[ "${REQUEST_HASH}" == "null" ]]; then
-  echo "Build request failed:"
+  echo "❌ Build request failed:"
   jq . <<< "${BUILD_RESPONSE}"
   exit 1
 fi
-echo "Request hash: ${REQUEST_HASH}"
+echo "🔑 Request hash: ${REQUEST_HASH}"
 
 while true; do
   HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' \
     "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
-  echo "Build status: ${HTTP_CODE}"
+  echo "⏳ Build status: ${HTTP_CODE}"
   if [[ "${HTTP_CODE}" == "200" ]]; then
     break
   elif [[ "${HTTP_CODE}" == "202" ]]; then
     sleep 10
   else
-    echo "Build failed (HTTP ${HTTP_CODE}):"
+    echo "❌ Build failed (HTTP ${HTTP_CODE}):"
     jq . /tmp/build_status.json
     exit 1
   fi
@@ -60,5 +62,5 @@ done
 BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
 IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
 IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
-echo "Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
-echo "sysupgrade -v -n -p ${IMAGE_URL}"
+echo "📋 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
+echo "🚀 sysupgrade -v -n -p ${IMAGE_URL}"

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 # Build custom OpenWrt firmware using the Sysupgrade API
-# Usage: build-firmware.sh <target> <profile> <host_vars_file> <defaults>
+# Usage: build-firmware.sh <target> <profile> <hostname>
 
 set -euxo pipefail
 
-TARGET="${1:?Usage: build-firmware.sh <target> <profile> <host_vars_file> <defaults>}"
+TARGET="${1:?Usage: build-firmware.sh <target> <profile> <hostname>}"
 PROFILE="${2:?}"
-HOST_VARS="${3:?}"
-DEFAULTS="${4:?}"
+HOSTNAME="${3:?}"
+
+HOST_VARS="ansible/host_vars/${HOSTNAME}"
+WIFI_SSID=$(yq '.wifi_ssid' "${HOST_VARS}")
+WIFI_PASSWORD_VAR=$(echo "${HOSTNAME}" | tr '[:lower:].-' '[:upper:]__')_WIFI_PASSWORD
+WIFI_PASSWORD="${!WIFI_PASSWORD_VAR:?Environment variable ${WIFI_PASSWORD_VAR} is not set}"
+
+DEFAULTS="uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
+uci set wireless.default_radio1.encryption='sae-mixed'
+uci set wireless.default_radio1.key='${WIFI_PASSWORD}'
+uci commit wireless"
 
 PACKAGES_JSON=$(yq -o=json '.openwrt_packages' "${HOST_VARS}")
 LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest |

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -10,9 +10,9 @@ HOST_VARS="${3:?}"
 DEFAULTS="${4:?}"
 
 PACKAGES_JSON=$(yq -o=json '.openwrt_packages' "${HOST_VARS}")
-LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest \
-  | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
-  | sort -V | tail -n 1)
+LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest |
+  jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' |
+  sort -V | tail -n 1)
 echo "Latest stable: ${LATEST_STABLE}"
 
 BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build custom OpenWrt firmware using the Sysupgrade API
+# Usage: build-firmware.sh <target> <profile> <host_vars_file> <defaults>
+
+set -euxo pipefail
+
+TARGET="${1:?Usage: build-firmware.sh <target> <profile> <host_vars_file> <defaults>}"
+PROFILE="${2:?}"
+HOST_VARS="${3:?}"
+DEFAULTS="${4:?}"
+
+PACKAGES_JSON=$(yq -o=json '.openwrt_packages' "${HOST_VARS}")
+LATEST_STABLE=$(curl -sL --compressed https://sysupgrade.openwrt.org/api/v1/latest \
+  | jq -r '.latest[] | select(test("-rc[0-9]+$") | not) | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
+  | sort -V | tail -n 1)
+echo "Latest stable: ${LATEST_STABLE}"
+
+BUILD_RESPONSE=$(curl -s --compressed -X POST https://sysupgrade.openwrt.org/api/v1/build \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n \
+    --arg target "${TARGET}" \
+    --arg profile "${PROFILE}" \
+    --arg version "${LATEST_STABLE}" \
+    --argjson packages "${PACKAGES_JSON}" \
+    --arg defaults "${DEFAULTS}" \
+    '{target: $target, profile: $profile, version: $version, packages: $packages, diff_packages: false, defaults: $defaults}')")
+
+REQUEST_HASH=$(jq -r '.request_hash' <<< "${BUILD_RESPONSE}")
+if [[ "${REQUEST_HASH}" == "null" ]]; then
+  echo "Build request failed:"
+  jq . <<< "${BUILD_RESPONSE}"
+  exit 1
+fi
+echo "Request hash: ${REQUEST_HASH}"
+
+while true; do
+  HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' \
+    "https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}")
+  echo "Build status: ${HTTP_CODE}"
+  if [[ "${HTTP_CODE}" == "200" ]]; then
+    break
+  elif [[ "${HTTP_CODE}" == "202" ]]; then
+    sleep 10
+  else
+    echo "Build failed (HTTP ${HTTP_CODE}):"
+    jq . /tmp/build_status.json
+    exit 1
+  fi
+done
+
+BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
+IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
+IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
+echo "Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
+echo "sysupgrade -v -n -p ${IMAGE_URL}"

--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -13,8 +13,7 @@ WIFI_SSID=$(yq '.wifi_ssid' "${HOST_VARS}")
 WIFI_PASSWORD_VAR=$(echo "${HOSTNAME}" | tr '[:lower:].-' '[:upper:]__')_WIFI_PASSWORD
 WIFI_PASSWORD="${!WIFI_PASSWORD_VAR:?Environment variable ${WIFI_PASSWORD_VAR} is not set}"
 
-DEFAULTS="uci delete wireless.radio0.disabled
-uci delete wireless.radio1.disabled
+DEFAULTS="uci delete wireless.default_radio1.disabled
 uci set wireless.default_radio1.ssid='${WIFI_SSID} 5 GHz'
 uci set wireless.default_radio1.encryption='sae-mixed'
 uci set wireless.default_radio1.key='${WIFI_PASSWORD}'
@@ -42,7 +41,6 @@ if [[ "${REQUEST_HASH}" == "null" ]]; then
   jq . <<< "${BUILD_RESPONSE}"
   exit 1
 fi
-echo "🔑 Request hash: ${REQUEST_HASH}"
 
 while true; do
   HTTP_CODE=$(curl -s --compressed -o /tmp/build_status.json -w '%{http_code}' \
@@ -62,5 +60,5 @@ done
 BIN_DIR=$(jq -r '.bin_dir' /tmp/build_status.json)
 IMAGE_NAME=$(jq -r '.images[] | select(.type == "sysupgrade") | .name' /tmp/build_status.json)
 IMAGE_URL="https://sysupgrade.openwrt.org/store/${BIN_DIR}/${IMAGE_NAME}"
-echo "📋 Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
+echo "Build status JSON: https://sysupgrade.openwrt.org/api/v1/build/${REQUEST_HASH}"
 echo "🚀 sysupgrade -v -n -p ${IMAGE_URL}"


### PR DESCRIPTION
## Summary

- Add `build-firmware:gate-bracha-xvx-cz` mise task for ZyXEL
  NBG6617 firmware builds
- Extract common build logic into `scripts/build-firmware.sh`
  (DRY up mise tasks)
- Move WiFi 5 GHz defaults (SSID, encryption, password) into
  `build-firmware.sh`, deriving env var names from hostname
- Enable WiFi radio on first boot by deleting
  `wireless.default_radio1.disabled` in firmware defaults
- Add `passlib` as `--preinstall` dependency for Ansible via mise
- Enable `backup: true` on all copy/template/replace tasks to
  create timestamped backups before changes
- Add router reboot task at the end of the Ansible playbook
- Add emojis to build script output for readability
- Split `run` task into per-host `run-ansible:*` tasks with
  `--limit`

## Testing

- `build-firmware:gate-bracha-xvx-cz` tested end-to-end
  successfully (OpenWrt 25.12.3)
- `build-firmware:gate-xvx-cz` tested end-to-end successfully
- Ansible playbook verified with `passlib` dependency