### PR TITLE
fix: remove unconditional reboot task from playbook

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -20,11 +20,6 @@
 
     - name: Include specific tasks
       ansible.builtin.include_tasks: tasks/tasks_{{ inventory_hostname }}.yml
-
-    - name: Reboot the router
-      ansible.builtin.command: reboot
-      changed_when: true
-
   handlers:
     - name: Import handlers
       ansible.builtin.import_tasks: handlers/main.yml


### PR DESCRIPTION
## Summary

- Remove the unconditional `reboot` task that ran at the end of every playbook execution
- The router no longer reboots after every Ansible run, allowing configuration changes (e.g., samba4) to apply without unnecessary downtime