### PR TITLE
chore: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,13 +30,13 @@ jobs:
 
       - name: Initialize CodeQL
         # Does not support arm64
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: actions
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           category: "/language:actions"

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -25,3 +25,6 @@ jobs:
         env:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72
+          # Skip branch-name checks for automation bots. Ex. dependabot hardcodes the `dependabot/<ecosystem>/...` branch prefix and cannot satisfy Conventional Branch
+          CCHK_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"
+          CCHK_BRANCH_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"

--- a/.github/workflows/pr-slack-notification.yml
+++ b/.github/workflows/pr-slack-notification.yml
@@ -19,7 +19,11 @@ on:
     types:
       - submitted
 
-permissions: read-all
+permissions:
+  actions: read # needed for cache operations
+  contents: read # needed to checkout the repository
+  issues: read # needed to read issue comments
+  pull-requests: read # needed to read pull request details
 
 defaults:
   run:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,10 +51,10 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10
+        uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -40,7 +40,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: results.sarif
           # Set category to distinguish from other security scans


### PR DESCRIPTION
## Summary

- Update `github/codeql-action` to v4.35.4
- Update `renovatebot/github-action` to v46.1.13
- Fix renovate token creation to use `client-id` parameter (required by newer actions/create-github-app-token)
- Add bot author ignores to commit-check branch validation (copilot[bot], dependabot[bot], github-actions[bot])
- Expand `pr-slack-notification` permissions from `read-all` to explicit per-scope read permissions