### PR TITLE
chore: remove collectd processes plugin configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,34 +10,46 @@ Target hosts defined in `ansible/inventory/hosts`:
 - `gate.xvx.cz` (ASUS RT-AX53U) -- currently active
 - `gate-bracha.xvx.cz` (ZyXEL NBG6617) -- currently commented out
 
-## Build / Run / Lint Commands
+## Task Runner
+
+This repo uses [mise](https://mise.jdx.dev/) as the task runner.
+`mise.toml` defines tools (Ansible, fnox, pipx) and tasks:
 
 ```bash
-# Run the full playbook
-cd ansible && ansible-playbook --diff main.yml -i inventory/hosts
+# Run Ansible for a specific host
+mise run run-ansible:gate-xvx-cz
+mise run run-ansible:gate-bracha-xvx-cz
 
-# Install Ansible Galaxy dependencies
-ansible-galaxy install -r ansible/requirements.yml
+# Build custom OpenWrt firmware
+mise run build-firmware:gate-xvx-cz
+mise run build-firmware:gate-bracha-xvx-cz
+```
 
-# Lint Ansible playbooks
+## Secrets
+
+Secrets are fetched from AWS Parameter Store via
+[fnox](https://github.com/jdx/fnox) (see `fnox.toml`). The
+`mise.toml` `[env]` section loads them automatically. Ansible
+tasks access secrets via `lookup('env', 'VAR_NAME')` with
+`no_log: true`.
+
+## Lint Commands
+
+```bash
 ansible-lint ansible/
-
-# Lint Markdown
 rumdl ./*.md
-
-# Check links
 lychee --config lychee.toml .
-
-# Lint GitHub Actions workflows
 actionlint
-
-# Validate JSON files
 jsonlint --comments .github/renovate.json5
 ```
 
 There is no test suite. This is an infrastructure-as-code repository.
 CI runs MegaLinter (`.mega-linter.yml`) which orchestrates all
 linting. Validate changes locally with the tools listed above.
+
+Pre-commit hooks are configured (`.pre-commit-config.yaml`); install
+with `pre-commit install && pre-commit install --hook-type commit-msg`.
+Direct commits to `main`/`master` are blocked by pre-commit.
 
 ## Ansible Code Style
 
@@ -73,7 +85,8 @@ linting. Validate changes locally with the tools listed above.
 
 ### Ansible-lint Exceptions
 
-Configured in `ansible/.ansible-lint.yml`:
+Configured in `ansible/.ansible-lint.yml` (MegaLinter references it
+as `ansible/.ansible-lint`):
 
 - `package-latest` -- allowed
 - `yaml[comments]` -- allowed

--- a/ansible/files/gate-bracha.xvx.cz/etc/config/luci_statistics.j2
+++ b/ansible/files/gate-bracha.xvx.cz/etc/config/luci_statistics.j2
@@ -189,10 +189,6 @@ config statistics 'collectd_ping'
 	option Interval '30'
 	option Hosts 'www.google.com'
 
-config statistics 'collectd_processes'
-	option enable '0'
-	option Processes '{{ luci_statistics_collectd_processes_processes }}'
-
 config statistics 'collectd_sensors'
 	option enable '0'
 

--- a/ansible/files/gate.xvx.cz/etc/config/luci_statistics.j2
+++ b/ansible/files/gate.xvx.cz/etc/config/luci_statistics.j2
@@ -189,10 +189,6 @@ config statistics 'collectd_ping'
 	option Interval '30'
 	option Hosts 'www.google.com'
 
-config statistics 'collectd_processes'
-	option enable '1'
-	option Processes '{{ luci_statistics_collectd_processes_processes }}'
-
 config statistics 'collectd_sensors'
 	option enable '0'
 

--- a/ansible/host_vars/gate-bracha.xvx.cz
+++ b/ansible/host_vars/gate-bracha.xvx.cz
@@ -13,8 +13,6 @@ interfaces:
   - phy1-ap0
   - wan@eth0
 
-luci_statistics_collectd_processes_processes: "collectd dnsmasq dropbear hostapd nlbwmon ntpd uhttpd vnstatd wpa_supplicant"
-
 luci_statistics_collectd_tcpconns_localports: "22 443"
 
 # Mailtrap API credentials
@@ -40,7 +38,6 @@ openwrt_packages:
   - collectd-mod-entropy
   - collectd-mod-ipstatistics
   - collectd-mod-ping
-  - collectd-mod-processes
   - collectd-mod-tcpconns
   - collectd-mod-uptime
   - htop

--- a/ansible/host_vars/gate.xvx.cz
+++ b/ansible/host_vars/gate.xvx.cz
@@ -31,8 +31,6 @@ interfaces:
 
 luci_homepage_openwrt_widget_password_hash: "{{ lookup('env', 'GATE_XVX_CZ_LUCI_HOMEPAGE_OPENWRT_WIDGET_PASSWORD_HASH') }}"
 
-luci_statistics_collectd_processes_processes: "cloudflared collectd dnsmasq dropbear hostapd nlbwmon ntpd uhttpd vnstatd wpa_supplicant"
-
 luci_statistics_collectd_tcpconns_localports: "21 22 443"
 
 # Mailtrap API credentials
@@ -58,7 +56,6 @@ openwrt_packages:
   - collectd-mod-entropy
   - collectd-mod-ipstatistics
   - collectd-mod-ping
-  - collectd-mod-processes
   - collectd-mod-tcpconns
   - collectd-mod-uptime
   - htop


### PR DESCRIPTION
## Summary

- Remove `collectd_processes` plugin configuration from luci_statistics templates for both hosts
- Remove `collectd-mod-processes` package from openwrt_packages lists
- Remove `luci_statistics_collectd_processes_processes` variable from host_vars