### PR TITLE
feat: set hostname during firmware build

### DIFF
--- a/scripts/build-firmware.sh
+++ b/scripts/build-firmware.sh
@@ -17,8 +17,13 @@ RANDOM_SUFFIX=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 10 || true)
 ROOT_PASSWORD="${HOSTNAME}12345${RANDOM_SUFFIX}"
 echo "🔑 Root password: ${ROOT_PASSWORD}"
 
+SHORT_HOSTNAME="${HOSTNAME%%.*}"
+
 DEFAULTS="exec > /root/uci-defaults.log 2>&1
 set -x
+
+# Set hostname
+sed -i \"s/option hostname .*/option hostname '${SHORT_HOSTNAME}'/\" /etc/config/system
 
 # Configure WiFi
 uci delete wireless.default_radio1.disabled


### PR DESCRIPTION
## Summary

- Set the device hostname in the UCI defaults script during firmware
  build using `sed` on `/etc/config/system`
- Extract short hostname from FQDN (e.g., `gate` from `gate.xvx.cz`)