### PR TITLE
fix: harden backup/restore script with trap cleanup and service state preservation

### DIFF
--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -20,11 +20,46 @@ COLLECTD_DIR_BASENAME="$(basename "${COLLECTD_DIR}")"
 NLBWMON_DIR="$(uci get nlbwmon.@nlbwmon[0].database_directory)"
 NLBWMON_DIR_BASENAME="$(basename "${NLBWMON_DIR}")"
 
-backup_database() {
+SERVICES_STOPPED=0
+COLLECTD_WAS_RUNNING=0
+NLBWMON_WAS_RUNNING=0
+VNSTAT_WAS_RUNNING=0
+
+is_service_running() {
+  /etc/init.d/"$1" running 2> /dev/null
+}
+
+restart_services() {
+  if [ "${SERVICES_STOPPED}" -eq 1 ]; then
+    logger -t "${LOGGER_TAG}" -p info "restarting previously running services"
+    [ "${COLLECTD_WAS_RUNNING}" -eq 1 ] && /etc/init.d/collectd start
+    [ "${NLBWMON_WAS_RUNNING}" -eq 1 ] && /etc/init.d/nlbwmon start
+    [ "${VNSTAT_WAS_RUNNING}" -eq 1 ] && /etc/init.d/vnstat start
+    SERVICES_STOPPED=0
+  fi
+}
+
+cleanup() {
+  logger -t "${LOGGER_TAG}" -p warning "interrupted, ensuring previously running services are restarted"
+  restart_services
+  trap - EXIT HUP INT TERM
+}
+
+stop_services() {
+  is_service_running collectd && COLLECTD_WAS_RUNNING=1
+  is_service_running nlbwmon && NLBWMON_WAS_RUNNING=1
+  is_service_running vnstat && VNSTAT_WAS_RUNNING=1
+
   logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
   /etc/init.d/collectd stop
   /etc/init.d/nlbwmon stop
   /etc/init.d/vnstat stop
+  SERVICES_STOPPED=1
+  trap cleanup EXIT HUP INT TERM
+}
+
+backup_database() {
+  stop_services
 
   echo -n "$(date) - Backup:" >> "${BACKUP_DIR}/log"
 
@@ -58,18 +93,13 @@ backup_database() {
   echo >> "${BACKUP_DIR}/log"
 
   if [ "$1" = "backup" ]; then
-    logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
-    /etc/init.d/collectd start
-    /etc/init.d/nlbwmon start
-    /etc/init.d/vnstat start
+    restart_services
   fi
+  trap - EXIT HUP INT TERM
 }
 
 restore_database() {
-  logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
-  /etc/init.d/collectd stop
-  /etc/init.d/nlbwmon stop
-  /etc/init.d/vnstat stop
+  stop_services
 
   echo -n "$(date) - Restore:" >> "${BACKUP_DIR}/log"
 
@@ -105,10 +135,8 @@ restore_database() {
 
   echo >> "${BACKUP_DIR}/log"
 
-  logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
-  /etc/init.d/collectd start
-  /etc/init.d/nlbwmon start
-  /etc/init.d/vnstat start
+  restart_services
+  trap - EXIT HUP INT TERM
 }
 
 # "reloaded" is a workaround to force the service to restore the data from the backup called when running on freshly installed router

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -31,10 +31,14 @@ is_service_running() {
 
 restart_services() {
   if [ "${SERVICES_STOPPED}" -eq 1 ]; then
-    logger -t "${LOGGER_TAG}" -p info "restarting previously running services"
-    [ "${COLLECTD_WAS_RUNNING}" -eq 1 ] && /etc/init.d/collectd start
-    [ "${NLBWMON_WAS_RUNNING}" -eq 1 ] && /etc/init.d/nlbwmon start
-    [ "${VNSTAT_WAS_RUNNING}" -eq 1 ] && /etc/init.d/vnstat start
+    if [ "${COLLECTD_WAS_RUNNING}" -eq 1 ] || [ "${NLBWMON_WAS_RUNNING}" -eq 1 ] || [ "${VNSTAT_WAS_RUNNING}" -eq 1 ]; then
+      logger -t "${LOGGER_TAG}" -p info "restarting previously running services"
+      [ "${COLLECTD_WAS_RUNNING}" -eq 1 ] && /etc/init.d/collectd start
+      [ "${NLBWMON_WAS_RUNNING}" -eq 1 ] && /etc/init.d/nlbwmon start
+      [ "${VNSTAT_WAS_RUNNING}" -eq 1 ] && /etc/init.d/vnstat start
+    else
+      logger -t "${LOGGER_TAG}" -p info "no services were running before, skipping restart"
+    fi
     SERVICES_STOPPED=0
   fi
 }

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -92,7 +92,7 @@ backup_database() {
 
   echo >> "${BACKUP_DIR}/log"
 
-  if [ "$1" = "backup" ]; then
+  if [ "$1" != "stop" ]; then
     restart_services
   fi
   trap - EXIT HUP INT TERM
@@ -149,7 +149,7 @@ start() {
 }
 
 stop() {
-  backup_database
+  backup_database stop
 }
 
 backup() {

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -22,9 +22,9 @@ NLBWMON_DIR_BASENAME="$(basename "${NLBWMON_DIR}")"
 
 backup_database() {
   logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
-  /etc/init.d/collectd stop 2>/dev/null
-  /etc/init.d/nlbwmon stop 2>/dev/null
-  /etc/init.d/vnstat stop 2>/dev/null
+  /etc/init.d/collectd stop
+  /etc/init.d/nlbwmon stop
+  /etc/init.d/vnstat stop
 
   echo -n "$(date) - Backup:" >> "${BACKUP_DIR}/log"
 
@@ -58,16 +58,16 @@ backup_database() {
   echo >> "${BACKUP_DIR}/log"
 
   logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
-  /etc/init.d/collectd start 2>/dev/null
-  /etc/init.d/nlbwmon start 2>/dev/null
-  /etc/init.d/vnstat start 2>/dev/null
+  /etc/init.d/collectd start
+  /etc/init.d/nlbwmon start
+  /etc/init.d/vnstat start
 }
 
 restore_database() {
   logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
-  /etc/init.d/collectd stop 2>/dev/null
-  /etc/init.d/nlbwmon stop 2>/dev/null
-  /etc/init.d/vnstat stop 2>/dev/null
+  /etc/init.d/collectd stop
+  /etc/init.d/nlbwmon stop
+  /etc/init.d/vnstat stop
 
   echo -n "$(date) - Restore:" >> "${BACKUP_DIR}/log"
 
@@ -104,9 +104,9 @@ restore_database() {
   echo >> "${BACKUP_DIR}/log"
 
   logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
-  /etc/init.d/collectd start 2>/dev/null
-  /etc/init.d/nlbwmon start 2>/dev/null
-  /etc/init.d/vnstat start 2>/dev/null
+  /etc/init.d/collectd start
+  /etc/init.d/nlbwmon start
+  /etc/init.d/vnstat start
 }
 
 # "reloaded" is a workaround to force the service to restore the data from the backup called when running on freshly installed router

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -92,7 +92,7 @@ backup_database() {
 
   echo >> "${BACKUP_DIR}/log"
 
-  if [ "$1" != "stop" ]; then
+  if [ "$1" = "backup" ]; then
     restart_services
   fi
   trap - EXIT HUP INT TERM
@@ -153,7 +153,7 @@ stop() {
 }
 
 backup() {
-  backup_database
+  backup_database backup
 }
 
 restore() {

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -57,10 +57,12 @@ backup_database() {
 
   echo >> "${BACKUP_DIR}/log"
 
-  logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
-  /etc/init.d/collectd start
-  /etc/init.d/nlbwmon start
-  /etc/init.d/vnstat start
+  if [ "$1" = "backup" ]; then
+    logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
+    /etc/init.d/collectd start
+    /etc/init.d/nlbwmon start
+    /etc/init.d/vnstat start
+  fi
 }
 
 restore_database() {

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -21,6 +21,11 @@ NLBWMON_DIR="$(uci get nlbwmon.@nlbwmon[0].database_directory)"
 NLBWMON_DIR_BASENAME="$(basename "${NLBWMON_DIR}")"
 
 backup_database() {
+  logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
+  /etc/init.d/collectd stop 2>/dev/null
+  /etc/init.d/nlbwmon stop 2>/dev/null
+  /etc/init.d/vnstat stop 2>/dev/null
+
   echo -n "$(date) - Backup:" >> "${BACKUP_DIR}/log"
 
   if [ ! -d "${COLLECTD_DIR}" ]; then
@@ -51,9 +56,19 @@ backup_database() {
   fi
 
   echo >> "${BACKUP_DIR}/log"
+
+  logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
+  /etc/init.d/collectd start 2>/dev/null
+  /etc/init.d/nlbwmon start 2>/dev/null
+  /etc/init.d/vnstat start 2>/dev/null
 }
 
 restore_database() {
+  logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
+  /etc/init.d/collectd stop 2>/dev/null
+  /etc/init.d/nlbwmon stop 2>/dev/null
+  /etc/init.d/vnstat stop 2>/dev/null
+
   echo -n "$(date) - Restore:" >> "${BACKUP_DIR}/log"
 
   if [ ! -d "${BACKUP_DIR}/${COLLECTD_DIR_BASENAME}" ]; then
@@ -87,6 +102,11 @@ restore_database() {
   fi
 
   echo >> "${BACKUP_DIR}/log"
+
+  logger -t "${LOGGER_TAG}" -p info "starting collectd nlbwmon vnstat services"
+  /etc/init.d/collectd start 2>/dev/null
+  /etc/init.d/nlbwmon start 2>/dev/null
+  /etc/init.d/vnstat start 2>/dev/null
 }
 
 # "reloaded" is a workaround to force the service to restore the data from the backup called when running on freshly installed router

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -50,12 +50,13 @@ stop_services() {
   is_service_running nlbwmon && NLBWMON_WAS_RUNNING=1
   is_service_running vnstat && VNSTAT_WAS_RUNNING=1
 
+  SERVICES_STOPPED=1
+  trap cleanup EXIT HUP INT TERM
+
   logger -t "${LOGGER_TAG}" -p info "stopping collectd nlbwmon vnstat services"
   /etc/init.d/collectd stop
   /etc/init.d/nlbwmon stop
   /etc/init.d/vnstat stop
-  SERVICES_STOPPED=1
-  trap cleanup EXIT HUP INT TERM
 }
 
 backup_database() {

--- a/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
+++ b/ansible/files/etc/init.d/collectd_nlbwmon_vnstat-backup.j2
@@ -3,10 +3,11 @@
 # Based on: https://openwrt.org/docs/guide-user/services/network_monitoring/vnstat
 
 EXTRA_COMMANDS="backup restore"
-EXTRA_HELP=<<EOF
+EXTRA_HELP=$(cat <<EOF
   backup  Backup collectd nlbwmon vnstat databases
   restore Restore collectd nlbwmon vnstat databases
 EOF
+)
 
 START=55
 STOP=15
@@ -66,14 +67,14 @@ stop_services() {
 backup_database() {
   stop_services
 
-  echo -n "$(date) - Backup:" >> "${BACKUP_DIR}/log"
+  printf '%s' "$(date) - Backup:" >> "${BACKUP_DIR}/log"
 
   if [ ! -d "${COLLECTD_DIR}" ]; then
     echo >> "${BACKUP_DIR}/log"
     logger -s -t "${LOGGER_TAG}" -p err "cannot backup, data directory ${COLLECTD_DIR} does not exist (yet)" 2>&1 | tee -a "${BACKUP_DIR}/log"
   else
     logger -t "${LOGGER_TAG}" -p info "backing up collectd database"
-    echo -n " collectd" >> "${BACKUP_DIR}/log"
+    printf '%s' " collectd" >> "${BACKUP_DIR}/log"
     rsync -a --delete "${COLLECTD_DIR}" "${BACKUP_DIR}/"
   fi
 
@@ -82,7 +83,7 @@ backup_database() {
     logger -s -t "${LOGGER_TAG}" -p err "cannot backup, data directory ${NLBWMON_DIR} does not exist (yet)" 2>&1 | tee -a "${BACKUP_DIR}/log"
   else
     logger -t "${LOGGER_TAG}" -p info "backing up nlbwmon database"
-    echo -n " nlbwmon" >> "${BACKUP_DIR}/log"
+    printf '%s' " nlbwmon" >> "${BACKUP_DIR}/log"
     rsync -a --delete "${NLBWMON_DIR}" "${BACKUP_DIR}/"
   fi
 
@@ -91,7 +92,7 @@ backup_database() {
     logger -s -t "${LOGGER_TAG}" -p err "cannot backup, data directory ${VNSTAT_DIR} does not exist (yet)" 2>&1 | tee -a "${BACKUP_DIR}/log"
   else
     logger -t "${LOGGER_TAG}" -p info "backing up vnstat database"
-    echo -n " vnstat" >> "${BACKUP_DIR}/log"
+    printf '%s' " vnstat" >> "${BACKUP_DIR}/log"
     rsync -a --delete "${VNSTAT_DIR}" "${BACKUP_DIR}/"
   fi
 
@@ -106,14 +107,14 @@ backup_database() {
 restore_database() {
   stop_services
 
-  echo -n "$(date) - Restore:" >> "${BACKUP_DIR}/log"
+  printf '%s' "$(date) - Restore:" >> "${BACKUP_DIR}/log"
 
   if [ ! -d "${BACKUP_DIR}/${COLLECTD_DIR_BASENAME}" ]; then
     echo >> "${BACKUP_DIR}/log"
     logger -s -t "${LOGGER_TAG}" -p err "cannot restore, backup file ${BACKUP_DIR}/${COLLECTD_DIR_BASENAME} does not exist (yet)" 2>&1 | tee -a "${BACKUP_DIR}/log"
   else
     logger -t "${LOGGER_TAG}" -p info "restoring database from ${BACKUP_DIR}/${COLLECTD_DIR_BASENAME}"
-    echo -n " collectd" >> "${BACKUP_DIR}/log"
+    printf '%s' " collectd" >> "${BACKUP_DIR}/log"
     [ ! -d "${COLLECTD_DIR}" ] && mkdir "${COLLECTD_DIR}"
     rsync -a --delete "${BACKUP_DIR}/${COLLECTD_DIR_BASENAME}/" "${COLLECTD_DIR}/"
   fi
@@ -123,7 +124,7 @@ restore_database() {
     logger -s -t "${LOGGER_TAG}" -p err "cannot restore, backup file ${BACKUP_DIR}/${NLBWMON_DIR_BASENAME} does not exist (yet)" 2>&1 | tee -a "${BACKUP_DIR}/log"
   else
     logger -t "${LOGGER_TAG}" -p info "restoring database from ${BACKUP_DIR}/${NLBWMON_DIR_BASENAME}"
-    echo -n " nlbwmon" >> "${BACKUP_DIR}/log"
+    printf '%s' " nlbwmon" >> "${BACKUP_DIR}/log"
     [ ! -d "${NLBWMON_DIR}" ] && mkdir "${NLBWMON_DIR}"
     rsync -a --delete "${BACKUP_DIR}/${NLBWMON_DIR_BASENAME}/" "${NLBWMON_DIR}/"
   fi
@@ -133,7 +134,7 @@ restore_database() {
     logger -s -t "${LOGGER_TAG}" -p err "cannot restore, backup file ${BACKUP_DIR}/${VNSTAT_DIR_BASENAME} does not exist (yet)" 2>&1 | tee -a "${BACKUP_DIR}/log"
   else
     logger -t "${LOGGER_TAG}" -p info "restoring database from ${BACKUP_DIR}/${VNSTAT_DIR_BASENAME}"
-    echo -n " vnstat" >> "${BACKUP_DIR}/log"
+    printf '%s' " vnstat" >> "${BACKUP_DIR}/log"
     [ ! -d "${VNSTAT_DIR}" ] && mkdir "${VNSTAT_DIR}"
     rsync -a --delete "${BACKUP_DIR}/${VNSTAT_DIR_BASENAME}/" "${VNSTAT_DIR}/"
   fi

--- a/ansible/host_vars/gate-bracha.xvx.cz
+++ b/ansible/host_vars/gate-bracha.xvx.cz
@@ -13,7 +13,6 @@ interfaces:
   - eth0
   - phy0-ap0
   - phy1-ap0
-  - wan@eth0
 
 luci_statistics_collectd_tcpconns_localports: "22 443"
 

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -272,5 +272,4 @@
 
 - name: Restore data using collectd_nlbwmon_vnstat-backup
   ansible.builtin.command: /etc/init.d/collectd_nlbwmon_vnstat-backup restore
-  args:
-    creates: /tmp/rrd/{{ inventory_hostname_short }}/cpu-0
+  changed_when: false


### PR DESCRIPTION
## Summary

- Add trap/cleanup handler to ensure previously-running services are
  restarted on error or interrupt during backup/restore operations
- Capture pre-run running state of collectd, nlbwmon, and vnstat so
  only services that were actually running get restarted
- Install cleanup trap before stopping services to cover interruptions
  during the stop phase
- Pass explicit `backup` argument from `backup()` so cron-driven
  backups correctly restart services
- Gate restart log message to avoid misleading entries when no services
  were previously running
- Fix shellcheck warnings: heredoc syntax (SC1073) and replace
  `echo -n` with `printf` for POSIX compliance (SC3037)