### PR TITLE
docs: update README to match mise.toml tasks and remove notes section

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Build custom firmware using the OpenWrt Sysupgrade API:
 mise run build-firmware:gate-xvx-cz
 ```
 
-Run Ansible playbook:
+Build firmware, flash, and configure using Ansible:
+
+```bash
+mise run run-ansible-firmware:gate-xvx-cz
+```
+
+Run Ansible playbook (without firmware build):
 
 ```bash
 mise run run-ansible:gate-xvx-cz
@@ -31,42 +37,14 @@ Build custom firmware using the OpenWrt Sysupgrade API:
 mise run build-firmware:gate-bracha-xvx-cz
 ```
 
-Run Ansible playbook:
+Build firmware, flash, and configure using Ansible:
+
+```bash
+mise run run-ansible-firmware:gate-bracha-xvx-cz
+```
+
+Run Ansible playbook (without firmware build):
 
 ```bash
 mise run run-ansible:gate-bracha-xvx-cz
-```
-
----
-
-## Notes
-
-### Flash router and allow SSH access to the router form the WAN
-
-```bash
-# Set root password
-passwd
-
-# Enable SSH access from the WAN
-wget https://github.com/ruzickap.keys -O /etc/dropbear/authorized_keys
-
-cat >> /etc/config/firewall << 'EOF'
-
-config rule
-	option name 'Allow-SSH'
-	option src 'wan'
-	option target 'ACCEPT'
-	option proto 'tcp'
-	option dest_port '22'
-
-config redirect
-	option name 'Allow-SSH-22222'
-	option src 'wan'
-	option proto 'tcp'
-	option src_dport '22222'
-	option dest 'lan'
-	option dest_port '22'
-EOF
-
-/etc/init.d/firewall restart
 ```


### PR DESCRIPTION
## Summary

- Add missing `run-ansible-firmware` tasks for both hosts to match `mise.toml`
- Remove obsolete SSH access notes section