### PR TITLE
fix: enable openwrt/rootfs version updates via regex versioning

### DIFF
--- a/.github/workflows/ansible-openwrt-test.yml
+++ b/.github/workflows/ansible-openwrt-test.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash -euxo pipefail {0}
 
 env:
-  # renovate: datasource=docker depName=openwrt/rootfs
+  # renovate: datasource=docker depName=openwrt/rootfs versioning=regex:^(?<compatibility>x86_64)-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   OPENWRT_VERSION: "x86_64-25.12.2"
 
 jobs:


### PR DESCRIPTION
## Problem

Renovate never offered version updates for `openwrt/rootfs`. The tag format
`x86_64-<version>` (e.g. `x86_64-25.12.2`) is invalid under `semver`, so the
only thing Renovate produced was a digest pin — which fails because the value
lives in a plain env var with no `@sha256:` slot.

## Fix

Use `regex` versioning that treats the `x86_64` arch prefix as a
**compatibility** constraint and parses `major`/`minor`/`patch`:

```
# renovate: datasource=docker depName=openwrt/rootfs versioning=regex:^(?<compatibility>x86_64)-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
OPENWRT_VERSION: "x86_64-25.12.2"
```

This lets Renovate compare and upgrade `x86_64-*` tags (and only those — it
won't suggest `aarch64-*` or other arches).

## Verification

Real Renovate lookup (Node 24) against live Docker Hub tags:

- `x86_64-25.12.2` → **patch** update to `x86_64-25.12.4`, `skipReason: None`,
  **no** `pinDigest`.
- An older value `x86_64-24.10.0` correctly yields both a patch
  (`x86_64-24.10.7`) and a major (`x86_64-25.12.4`).
- `actionlint` passes on the workflow.

## Related

Complements the digest-pin suppression in
ruzickap/my-git-projects#363 (which stops the failing pin). This PR makes the
dependency actually track new releases instead of being unmanaged.