### PR TITLE
fix: update raspberrypi-wifi MAC address for gate.xvx.cz

### DIFF
--- a/ansible/host_vars/gate.xvx.cz
+++ b/ansible/host_vars/gate.xvx.cz
@@ -5,7 +5,7 @@ dhcp_hosts:
   # keep-sorted start
   - ip: "{{ network_prefix }}.2"
     name: raspberrypi-wifi
-    mac: a0:f3:c1:1b:de:a6
+    mac: 90:de:80:3e:93:fc
     # mac: dc:a6:32:0e:bd:14
   - ip: "{{ network_prefix }}.3"
     name: uzg-01-nic


### PR DESCRIPTION
## Description

Updates the DHCP static lease MAC address for the `raspberrypi-wifi` host
in `ansible/host_vars/gate.xvx.cz` to reflect the device's current
wireless interface MAC (`90:de:80:3e:93:fc`).

## Motivation

The previous MAC (`a0:f3:c1:1b:de:a6`) no longer matches the device, so the
static lease was not being applied.

## Changes

- Update `mac` for `raspberrypi-wifi` in the `dhcp_hosts` list.