### PR TITLE
ci: configure renovate for OPENWRT_VERSION

### DIFF
--- a/.github/workflows/ansible-openwrt-test.yml
+++ b/.github/workflows/ansible-openwrt-test.yml
@@ -19,8 +19,8 @@ defaults:
     shell: bash -euxo pipefail {0}
 
 env:
-  # renovate: datasource=docker depName=openwrt/rootfs versioning=regex:^(?<compatibility>x86_64)-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-  OPENWRT_VERSION: "x86_64-25.12.4"
+  # renovate: datasource=docker depName=openwrt/rootfs extractVersion=^x86_64-(?<version>\d+\.\d+\.\d+)$
+  OPENWRT_VERSION: "25.12.4"
 
 jobs:
   gate-xvx-cz:
@@ -39,7 +39,7 @@ jobs:
             --hostname gate \
             -p 2222:22 \
             --entrypoint /bin/sh \
-            "openwrt/rootfs:${OPENWRT_VERSION}" \
+            "openwrt/rootfs:x86_64-${OPENWRT_VERSION}" \
             -c "sleep infinity"
 
           # Wait for container to be ready


### PR DESCRIPTION
## What

Configure Renovate to update the `OPENWRT_VERSION` env var in
`.github/workflows/ansible-openwrt-test.yml`.

- Use `extractVersion=^x86_64-(?<version>\d+\.\d+\.\d+)$` so Renovate strips
  the `x86_64-` prefix from upstream `openwrt/rootfs` Docker tags and parses
  the value as plain semver (via the global config's default `versioningTemplate`).
- Move the `x86_64-` prefix out of the value and into the image tag template
  (`openwrt/rootfs:x86_64-${OPENWRT_VERSION}`). The resulting tag is unchanged.

## Why

The previous annotation used
`versioning=regex:^(?<compatibility>x86_64)-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$`,
which described the `x86_64-<x.y.z>` tag shape. With the extracted
`currentValue` being `25.12.4` (no prefix), the regex versioning failed to
parse it, so Renovate produced **no** updates.

The `extractVersion` regex also rejects the noisy upstream variants
(`x86_64-v25.12.4`, `x86-64-25.12.4`, `x86_64-25.12-SNAPSHOT`, `x86_64-master`,
`x86_64-openwrt-25.12`), keeping only proper 3-part releases.